### PR TITLE
Fix: change webex service to use helper

### DIFF
--- a/src/app/service/webex_service.py
+++ b/src/app/service/webex_service.py
@@ -2,14 +2,15 @@ import os
 import requests
 from datetime import datetime
 import urllib.parse
+from ..helper import PenpalsHelper as helper
 
 class WebexService:
     BASE_URL = "https://webexapis.com/v1"
     
     def __init__(self):
-        self.client_id = os.getenv('WEBEX_CLIENT_ID')
-        self.client_secret = os.getenv('WEBEX_CLIENT_SECRET')
-        self.redirect_uri = os.getenv('WEBEX_REDIRECT_URI')
+        self.client_id = helper.get_env_variable('WEBEX_CLIENT_ID')
+        self.client_secret = helper.get_env_variable('WEBEX_CLIENT_SECRET')
+        self.redirect_uri = helper.get_env_variable('WEBEX_REDIRECT_URI')
         
     def get_auth_url(self):
         """Generate the WebEx OAuth authorization URL"""


### PR DESCRIPTION
<insert number below>
  
## 

## Description
<At least a sentence or two> 
This PR is part of a series of failed PRs that attempt to restore access to Webex API secrets on our Azure deployment. The changes made in this PR did not make the environment variables visible in the Azure environment and are to reverted.

This PR was also directly merged into main as this was the only possiblity to test changes on Azure during development.

## Checklist
<Type x in place of the space bar to tick each one off> 

- [x] I have verified that my change compiles properly.
- [x] I have ensured that the changes are formatted correctly.
- [x] I have checked that this change does not create additional warnings.
- [x] I have assigned MYSELF to the PR and added any relevant labels.

## Next steps
<State whether this is the end or if there is a continuation via a new issue>
- revert this PR
- **FIND POSSIBLITY TO TEST AZURE ENVIROMENT WITHOUT MERGING INTO MAIN** 
